### PR TITLE
feat: added scope option and use npm name suggestion package

### DIFF
--- a/index.js
+++ b/index.js
@@ -54,9 +54,14 @@ function initOpts () {
           message: 'Package name:',
           validate: npm.validatePackageName,
           default: (promptInput, allInput) => {
-            return packageName(allInput.name, allInput.cwd)
+            return packageName(allInput.name, allInput.scope, allInput.cwd)
           }
         }
+      },
+      scope: {
+        type: 'string',
+        description: 'Set a scope to be used when suggesting a package name',
+        prompt: false
       },
       version: {
         type: 'string',

--- a/lib/package-name.js
+++ b/lib/package-name.js
@@ -1,17 +1,19 @@
 'use strict'
-const path = require('path')
 const npa = require('npm-package-arg')
+const nameFromFolder = require('@npmcli/name-from-folder')
 
-module.exports = function scopeAndName (_name, cwd) {
+module.exports = function scopeAndName (_name, _scope, cwd) {
   let name = _name
+  const scope = _scope
   if (!name) {
-    const baseName = path.basename(cwd)
-    const scope = path.basename(path.dirname(cwd))
-    if (scope.startsWith('@')) {
-      name = `${scope}/${baseName}`
-    } else {
-      name = baseName
+    name = nameFromFolder(cwd)
+  }
+  if (scope) {
+    if (name.startsWith('@')) {
+      const [, n] = name.split('/')
+      name = n
     }
+    name = `${scope}/${name}`
   }
   return npa(name).name
 }

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   },
   "license": "ICS",
   "dependencies": {
+    "@npmcli/name-from-folder": "^1.0.1",
     "fs-extra": "^9.0.1",
     "loggerr": "^3.0.0",
     "npm-package-arg": "^8.0.1",


### PR DESCRIPTION
This removes the old custom logic we had for deriving a name suggestion and replaces it mostly with npm's package for that.  It does add an option for `--scope` which would override the derived scope in case you want to always suggest a specific scope.

I am just going to merge this to the `1.x` branch, if we have any issues or any feedback we can always change it before we cut the final release.

cc @boneskull