### PR TITLE
fix(ci): updated ci and improved release scripts

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,8 +3,11 @@ name: Test
 on:
   push:
     branches:
-    - main
+      - main
   pull_request:
+
+permissions:
+  content: read
 
 jobs:
   setup:
@@ -13,30 +16,41 @@ jobs:
     outputs:
       nodes: ${{ steps.nodes.outputs.nodes }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
       - name: Setup Node Version Matrix
         id: nodes
         run: |
           NODES=$(npx -y @pkgjs/nv ls supported | jq  '. | .version' | paste -sd "," -)
           echo "nodes=[${NODES}]" >> $GITHUB_OUTPUT
 
+  lint:
+    runs-on: ubuntu-latest
+    needs: setup
+    steps:
+      - uses: actions/checkout@v6
+      - name: Use Node.js 24.x
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24.x
+      - run: npm i
+      - run: npm run lint
+
   test:
-    # uses: pkgjs/action/.github/workflows/node-test.yaml@v0
     runs-on: ubuntu-latest
     needs: setup
     strategy:
       matrix:
         node-version: ${{ fromJson(needs.setup.outputs.nodes) }}
     steps:
-    - uses: actions/checkout@v4
-    - name: Setup git user
-      run: |
-          git config --global user.name "$(git --no-pager log --format=format:'%an' -n 1)"
-          git config --global user.email "$(git --no-pager log --format=format:'%ae' -n 1)"
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v3
-      with:
-        node-version: ${{ matrix.node-version }}
-    - name: npm install and test
-      run: npm it
+      - uses: actions/checkout@v6
+      - name: Setup git user
+        run: |
+            git config --global user.name "$(git --no-pager log --format=format:'%an' -n 1)"
+            git config --global user.email "$(git --no-pager log --format=format:'%ae' -n 1)"
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v6
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: npm install and test
+        run: npm it

--- a/package.json
+++ b/package.json
@@ -8,13 +8,15 @@
     "create-package-json": "bin/create-package-json"
   },
   "scripts": {
-    "test": "semistandard && mocha",
+    "test": "mocha",
     "test:debug": "mocha --inspect --inspect-brk --timeout=0",
     "test:cover": "c8 mocha",
+    "lint": "semistandard",
     "lint:fix": "semistandard --fix",
     "debug": "mocha --inspect --inspect-brk",
-    "release": "npm t && standard-version && npm publish",
-    "postpublish": "git push && git push --tags"
+    "prerelease": "npm run lint && npm test && standard-version && npm login",
+    "release": "npm publish --access=public --tag=\"${1:-latest}\"",
+    "postrelease": "(npm logout || true) && git push --follow-tags && gh release create --draft --generate-notes \"v$(cat package.json | jq -r .version)\""
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Updated CI versions, split out `lint` task so it is not run in each CI matrix version, and updated release scripts to add npm login/out and creating a GH release.

<!--
Thank you for your pull request. Please provide a description and 
note the Certificate of Origin below. 

-->

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
